### PR TITLE
Add Changelog

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.2
+_commit: v0.0.2-8-gae5ab74
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.devcontainer/on-create-command.sh
+++ b/.devcontainer/on-create-command.sh
@@ -6,3 +6,7 @@ set -ex
 git config --global --add safe.directory /workspaces/copier-python-package-template
 
 sh .devcontainer/on-create-command-boilerplate.sh
+
+sh .devcontainer/manual-setup-deps.sh
+
+pre-commit install --install-hooks

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## 📜 Our Pledge
+
+We, as members, contributors, and leaders of this project, pledge to make participation in our community a **harassment-free experience for everyone**, regardless of:
+
+- Age
+- Body size
+- Visible or invisible disability
+- Ethnicity
+- Gender identity and expression
+- Level of experience
+- Nationality
+- Personal appearance
+- Race
+- Religion
+- Sexual identity and orientation
+
+We are committed to fostering an environment where everyone feels **respected, safe, and welcome**.
+
+---
+
+## 🤝 Our Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+- Using **welcoming and inclusive** language
+- Being **respectful** of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is **best for the community**
+- Showing **empathy** towards other community members
+
+Examples of unacceptable behavior include:
+
+- Using **sexualized language or imagery**, or making sexual advances
+- **Trolling**, insulting, or derogatory comments
+- Public or private **harassment**
+- Publishing private information, such as a physical or electronic address, without explicit permission
+- Conduct that is otherwise **inappropriate, threatening, or offensive**
+
+---
+
+## 🛠️ Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this **Code of Conduct** and are expected to take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to **remove, edit, or reject comments, commits, code, issues, and other contributions** that are not aligned with this Code of Conduct.
+
+---
+
+## 🚨 Reporting Issues
+
+If you experience or witness unacceptable behavior, or have concerns about a possible violation of this Code of Conduct, please report it by:
+
+- **Contacting a maintainer directly**
+
+Reports will be handled with **confidentiality**. We are committed to addressing issues promptly and fairly.
+
+---
+
+## 📅 Enforcement Guidelines
+
+Project maintainers will follow these guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Warning:** A private, written warning with clarity on what behavior was inappropriate.
+2. **Temporary Ban:** A temporary suspension from interacting within the community.
+3. **Permanent Ban:** A permanent ban from the community or project spaces.
+
+---
+
+## 📜 Scope
+
+This Code of Conduct applies in all project spaces, including:
+
+- GitHub repository
+- Pull requests and issues
+- Project-related communication channels (e.g., chat, email)
+
+It also applies when an individual is officially representing the project in public spaces.
+
+---
+
+## 📝 Attribution
+
+This Code of Conduct is adapted from the **Contributor Covenant**, version 2.1, available at:
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+
+For answers to common questions about this code of conduct, see:
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)
+
+---
+
+Thank you for helping make this community a safe, welcoming, and productive space for everyone! 🚀

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing
+
+Thank you for considering contributing! Contributions, whether big or small, are always welcome. Below are guidelines to help you get started.
+
+---
+
+## 📚 Table of Contents
+
+1. [Code of Conduct](#-code-of-conduct)
+2. [How to Contribute](#-how-to-contribute)
+3. [Issues and Bug Reports](#-issues-and-bug-reports)
+4. [Feature Requests](#-feature-requests)
+5. [Development Guidelines](#-development-guidelines)
+6. [Pull Requests](#-pull-requests)
+7. [License](#-license)
+
+---
+
+## 📜 Code of Conduct
+
+By participating in this project, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). Please ensure that you read and understand it.
+
+---
+
+## 🛠️ How to Contribute
+
+1. **Fork the repository** on GitHub.
+
+2. **Set up the Dev Container (Recommended Method)**
+   - Create a Github Codespace (`Code`->`Codespaces` in the Github web console of your cloned repository) OR click on the "Open in Devcontainer" link in the [Readme](./README.md)
+
+3. **Make Your Changes**
+   - Create a branch for your feature or bug fix:
+     ```bash
+     git checkout -b feature/your-feature-name
+     ```
+   - Make your changes and test them within the dev container.
+
+4. **Commit Your Changes**
+   ```bash
+   git add .
+   git commit -m "Add your detailed commit message"
+   ```
+
+5. **Push Your Changes**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+6. **Open a Pull Request (PR)**
+   - Go to the original repository on GitHub.
+   - Click **"New Pull Request"**.
+   - Fill in the PR template and submit.
+
+---
+
+### 🐳 Why Use the Dev Container?
+
+- Pre-configured environment ensures consistency across development setups.
+- No need to manually install dependencies locally.
+- Simplifies debugging and testing workflows.
+
+If you encounter issues with the dev container, feel free to raise an **Issue**.
+
+---
+
+## 🐞 Issues and Bug Reports
+
+If you encounter a bug or issue:
+- Check if it’s already reported in the Issues section.
+- If not, open a **new issue** with:
+  - A clear and descriptive title.
+  - Steps to reproduce the issue.
+  - Expected and actual behavior.
+  - Any relevant logs, screenshots, or environment details.
+
+---
+
+## 💡 Feature Requests
+
+We love hearing new ideas! If you have an idea for a feature:
+- Search existing issues to ensure it hasn't been suggested already.
+- Open a new **Feature Request** issue and describe:
+   - What the feature does.
+   - Why it’s beneficial.
+   - How you envision it being implemented.
+
+---
+
+## 🧑‍💻 Development Guidelines
+
+- Follow the project's code style.
+- Write clear and descriptive commit messages.
+- Use Test Driven Development when adding new features or fixing bugs.
+- Keep changes focused; avoid mixing unrelated changes in one pull request.
+
+---
+
+## 🔄 Pull Requests
+
+- Ensure your pull request is focused on a single feature or bug fix.
+- Reference the issue your pull request addresses (if applicable).
+- Update documentation if your changes require it.
+- Be ready to address feedback or changes requested during code review.
+
+---
+
+## 📜 License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project: [LICENSE](./LICENSE).
+
+---
+
+Thank you for your contribution! 🚀
+
+If you have any questions, feel free to raise an **Issue**. 😊

--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@
 
 
 
-# Updating from the template
+## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
-`copier update --trust --defaults --conflict rej --vcs-ref main`
+`copier update --trust --defaults --conflict rej`

--- a/template/.devcontainer/on-create-command.sh.jinja
+++ b/template/.devcontainer/on-create-command.sh.jinja
@@ -5,4 +5,8 @@ set -ex
 # it doesn't have access to the workspace directory. This can normally be done in post-start-command
 git config --global --add safe.directory /workspaces/{% endraw %}{{ repo_name }}{% raw %}
 
-sh .devcontainer/on-create-command-boilerplate.sh{% endraw %}
+sh .devcontainer/on-create-command-boilerplate.sh
+
+sh .devcontainer/manual-setup-deps.sh
+
+pre-commit install --install-hooks{% endraw %}

--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -75,7 +75,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Unit test
-        run: uv run pytest --cov-report=xml
+        run: uv run pytest --cov-report=xml --durations=5
 
       - name: Upload coverage to Codecov
         # only upload coverage from fastest job

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -1,0 +1,77 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+---
+
+## [Unreleased]
+
+### Added
+- Describe new features added in this version.
+
+### Changed
+- Describe changes in existing functionality.
+
+### Deprecated
+- List features that are still available but will be removed in future versions.
+
+### Removed
+- List features that have been removed.
+
+### Fixed
+- List any bug fixes.
+
+### Security
+- Describe security fixes or improvements.
+
+---
+
+## [0.1.0] - 2024-12-18
+
+### Added
+- Project setup.
+- Initial functionality implemented.
+
+---
+
+### How to Use This Changelog
+
+- **Added:** For new features.
+- **Changed:** For changes in existing functionality.
+- **Deprecated:** For features that will soon be removed.
+- **Removed:** For features that have been removed.
+- **Fixed:** For bug fixes.
+- **Security:** In case of vulnerabilities addressed.
+
+---
+
+### Versioning
+
+This project uses **Semantic Versioning (MAJOR.MINOR.PATCH)**:
+- **MAJOR:** Incompatible API changes.
+- **MINOR:** Backward-compatible new features.
+- **PATCH:** Backward-compatible bug fixes.
+
+For example:
+- `1.0.0`: Major release with breaking changes.
+- `1.1.0`: New backward-compatible feature.
+- `1.1.1`: Bug fix or minor change.
+
+---
+
+### Contributing to the Changelog
+
+When contributing changes, ensure you update the `[Unreleased]` section of this file with a brief description of your contribution.
+
+- Use clear, concise language.
+- Categorize your change under **Added**, **Changed**, **Deprecated**, **Removed**, **Fixed**, or **Security**.
+
+When releasing a new version:
+1. Move changes from `[Unreleased]` to a new section with the version number and release date.
+2. Update any relevant documentation if necessary.
+
+---
+
+Thank you for helping us maintain a clean and clear changelog! 🚀

--- a/template/CODE_OF_CONDUCT.md
+++ b/template/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Code of Conduct
+
+## 📜 Our Pledge
+
+We, as members, contributors, and leaders of this project, pledge to make participation in our community a **harassment-free experience for everyone**, regardless of:
+
+- Age
+- Body size
+- Visible or invisible disability
+- Ethnicity
+- Gender identity and expression
+- Level of experience
+- Nationality
+- Personal appearance
+- Race
+- Religion
+- Sexual identity and orientation
+
+We are committed to fostering an environment where everyone feels **respected, safe, and welcome**.
+
+---
+
+## 🤝 Our Standards
+
+Examples of behavior that contribute to a positive environment include:
+
+- Using **welcoming and inclusive** language
+- Being **respectful** of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is **best for the community**
+- Showing **empathy** towards other community members
+
+Examples of unacceptable behavior include:
+
+- Using **sexualized language or imagery**, or making sexual advances
+- **Trolling**, insulting, or derogatory comments
+- Public or private **harassment**
+- Publishing private information, such as a physical or electronic address, without explicit permission
+- Conduct that is otherwise **inappropriate, threatening, or offensive**
+
+---
+
+## 🛠️ Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing this **Code of Conduct** and are expected to take appropriate and fair corrective action in response to any behavior they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to **remove, edit, or reject comments, commits, code, issues, and other contributions** that are not aligned with this Code of Conduct.
+
+---
+
+## 🚨 Reporting Issues
+
+If you experience or witness unacceptable behavior, or have concerns about a possible violation of this Code of Conduct, please report it by:
+
+- **Contacting a maintainer directly**
+
+Reports will be handled with **confidentiality**. We are committed to addressing issues promptly and fairly.
+
+---
+
+## 📅 Enforcement Guidelines
+
+Project maintainers will follow these guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Warning:** A private, written warning with clarity on what behavior was inappropriate.
+2. **Temporary Ban:** A temporary suspension from interacting within the community.
+3. **Permanent Ban:** A permanent ban from the community or project spaces.
+
+---
+
+## 📜 Scope
+
+This Code of Conduct applies in all project spaces, including:
+
+- GitHub repository
+- Pull requests and issues
+- Project-related communication channels (e.g., chat, email)
+
+It also applies when an individual is officially representing the project in public spaces.
+
+---
+
+## 📝 Attribution
+
+This Code of Conduct is adapted from the **Contributor Covenant**, version 2.1, available at:
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct/](https://www.contributor-covenant.org/version/2/1/code_of_conduct/)
+
+For answers to common questions about this code of conduct, see:
+[https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq)
+
+---
+
+Thank you for helping make this community a safe, welcoming, and productive space for everyone! 🚀

--- a/template/CONTRIBUTING.md
+++ b/template/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing
+
+Thank you for considering contributing! Contributions, whether big or small, are always welcome. Below are guidelines to help you get started.
+
+---
+
+## 📚 Table of Contents
+
+1. [Code of Conduct](#-code-of-conduct)
+2. [How to Contribute](#-how-to-contribute)
+3. [Issues and Bug Reports](#-issues-and-bug-reports)
+4. [Feature Requests](#-feature-requests)
+5. [Development Guidelines](#-development-guidelines)
+6. [Pull Requests](#-pull-requests)
+7. [License](#-license)
+
+---
+
+## 📜 Code of Conduct
+
+By participating in this project, you agree to abide by our [Code of Conduct](./CODE_OF_CONDUCT.md). Please ensure that you read and understand it.
+
+---
+
+## 🛠️ How to Contribute
+
+1. **Fork the repository** on GitHub.
+
+2. **Set up the Dev Container (Recommended Method)**
+   - Create a Github Codespace (`Code`->`Codespaces` in the Github web console of your cloned repository) OR click on the "Open in Devcontainer" link in the [Readme](./README.md)
+
+3. **Make Your Changes**
+   - Create a branch for your feature or bug fix:
+     ```bash
+     git checkout -b feature/your-feature-name
+     ```
+   - Make your changes and test them within the dev container.
+
+4. **Commit Your Changes**
+   ```bash
+   git add .
+   git commit -m "Add your detailed commit message"
+   ```
+
+5. **Push Your Changes**
+   ```bash
+   git push origin feature/your-feature-name
+   ```
+
+6. **Open a Pull Request (PR)**
+   - Go to the original repository on GitHub.
+   - Click **"New Pull Request"**.
+   - Fill in the PR template and submit.
+
+---
+
+### 🐳 Why Use the Dev Container?
+
+- Pre-configured environment ensures consistency across development setups.
+- No need to manually install dependencies locally.
+- Simplifies debugging and testing workflows.
+
+If you encounter issues with the dev container, feel free to raise an **Issue**.
+
+---
+
+## 🐞 Issues and Bug Reports
+
+If you encounter a bug or issue:
+- Check if it’s already reported in the Issues section.
+- If not, open a **new issue** with:
+  - A clear and descriptive title.
+  - Steps to reproduce the issue.
+  - Expected and actual behavior.
+  - Any relevant logs, screenshots, or environment details.
+
+---
+
+## 💡 Feature Requests
+
+We love hearing new ideas! If you have an idea for a feature:
+- Search existing issues to ensure it hasn't been suggested already.
+- Open a new **Feature Request** issue and describe:
+   - What the feature does.
+   - Why it’s beneficial.
+   - How you envision it being implemented.
+
+---
+
+## 🧑‍💻 Development Guidelines
+
+- Follow the project's code style.
+- Write clear and descriptive commit messages.
+- Use Test Driven Development when adding new features or fixing bugs.
+- Keep changes focused; avoid mixing unrelated changes in one pull request.
+
+---
+
+## 🔄 Pull Requests
+
+- Ensure your pull request is focused on a single feature or bug fix.
+- Reference the issue your pull request addresses (if applicable).
+- Update documentation if your changes require it.
+- Be ready to address feedback or changes requested during code review.
+
+---
+
+## 📜 License
+
+By contributing, you agree that your contributions will be licensed under the same license as the project: [LICENSE](./LICENSE).
+
+---
+
+Thank you for your contribution! 🚀
+
+If you have any questions, feel free to raise an **Issue**. 😊

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -24,4 +24,4 @@ This project has a dev container. If you already have VS Code and Docker install
 
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
-`copier update --trust --defaults --conflict rej`
+`copier update --trust --defaults --conflict rej`{% endraw %}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -21,6 +21,7 @@ This project has a dev container. If you already have VS Code and Docker install
 
 
 
+
 ## Updating from the template
 This repository uses a copier template. To pull in the latest updates from the template, use the command:
-`copier update --trust --defaults --conflict rej --vcs-ref main`{% endraw %}
+`copier update --trust --defaults --conflict rej`


### PR DESCRIPTION
 ## Link to Issue or Slack thread
https://github.com/LabAutomationAndScreening/copier-python-package-template/issues/3


 ## Why is this change necessary?
Libraries should have Changelogs


 ## How does this change address the issue?
Creates a generic changelog as part of the template


 ## What side effects does this change have?
None


 ## How is this change tested?
pyalab repo


 ## Other
Also pulls in some misc upstream updates to add Code of Conduct and Contributing doc