### PR TITLE
Publish to code artifact

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.7-44-gea357db
+_commit: v0.0.8-1-g7ff0593
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.8-3-g2c970ed
+_commit: v0.0.8-4-g5211c85
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.8-5-g77c618a
+_commit: v0.0.9
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.8-4-g5211c85
+_commit: v0.0.8-5-g77c618a
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.8-1-g7ff0593
+_commit: v0.0.8-2-gfd4c577
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.8-2-gfd4c577
+_commit: v0.0.8-3-g2c970ed
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,8 +112,8 @@ jobs:
 
       - name: install new dependencies
         env:
+          # Provide a fake token so it doesn't attempt to access AWS to generate a new one when the script is run if CodeArtifact is set as the registry
           CODEARTIFACT_AUTH_TOKEN: 'faketoken'
-          UV_NO_CACHE: 'true'
         run: |
           # Remove any specification of a Python repository having a default other than PyPI...because in this CI pipeline we can only install from PyPI
           python $RUNNER_TEMP/replace_private_package_registries.py

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -28,6 +28,7 @@ class ContextUpdater(ContextHook):
         context["ephemeral_pulumi_deploy_version"] = "0.0.2"
         context["pydantic_version"] = "2.10.6"
         context["pyinstaller_version"] = "6.12.0"
+        context["setuptools_version"] = "76.0.0"
 
         context["gha_checkout"] = "v4.2.2"
         context["gha_setup_python"] = "v5.4.0"

--- a/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -38,12 +38,12 @@ else
             --output text $PROFILE_ARGS)
         set -x
     fi
-
+    # uv sometimes uses has better luck when setting the twine env vars
+    export TWINE_USERNAME=aws
     set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    export UV_INDEX_CODE_ARTIFACT_PRIMARY_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export TWINE_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
-    export UV_INDEX_CODE_ARTIFACT_STAGING_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -6,7 +6,7 @@ if [ -z "$AWS_PROFILE" ] && [ -z "$AWS_ACCESS_KEY_ID" ] && [ -z "$CODEARTIFACT_A
     echo "No AWS profile, access key, or auth token found, cannot proceed."
     exit 1
 else
-    # Only regenerate the token if it doesn't exist or wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
+    # Only regenerate the token if it wasn't already set as an environmental variable (e.g. during CI or passed into a docker image build)
     if [ -z "$CODEARTIFACT_AUTH_TOKEN" ]; then
         echo "Fetching CodeArtifact token"
         if [ -z "$CI" ]; then
@@ -30,7 +30,7 @@ else
         fi
 
         set +x
-        export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+        CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
             --domain {% endraw %}{{ repo_org_name }}{% raw %} \
             --domain-owner {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %} \
             --region {% endraw %}{{ aws_org_home_region }}{% raw %} \

--- a/template/.devcontainer/code-artifact-auth.sh.jinja
+++ b/template/.devcontainer/code-artifact-auth.sh.jinja
@@ -41,7 +41,9 @@ else
 
     set +x
     export UV_INDEX_CODE_ARTIFACT_PRIMARY_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export UV_INDEX_CODE_ARTIFACT_PRIMARY_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     export UV_INDEX_CODE_ARTIFACT_STAGING_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
+    export UV_INDEX_CODE_ARTIFACT_STAGING_PUBLISH_PASSWORD="$CODEARTIFACT_AUTH_TOKEN"
     set -x
 
 fi{% endraw %}{% else %}{% raw %}# Placeholder file not being used by these copier template answers{% endraw %}{% endif %}

--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -1,4 +1,4 @@
-{% raw %}name: Publish to PyPI
+{% raw %}name: Publish to Production Package Registry
 
 on:
   workflow_dispatch:
@@ -22,7 +22,10 @@ jobs:
       - name: Install latest versions of python packages
         uses: ./.github/actions/install_deps_uv
         with:
-          python-version: {% endraw %}{{ python_version }}{% raw %}
+          python-version: {% endraw %}{{ python_version }}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
 
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
@@ -69,7 +72,10 @@ jobs:
       - name: Install python tooling
         uses: ./.github/actions/install_deps_uv
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
 
       - name: Unit test
         run: uv run pytest --durations=5
@@ -85,7 +91,34 @@ jobs:
       - name: Install python tooling
         uses: ./.github/actions/install_deps_uv
         with:
-          python-version: {% endraw %}{{ python_version }}{% raw %}
+          python-version: {% endraw %}{{ python_version }}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
 
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+      - name: OIDC Auth for Installing any dependencies that uv may need for build (sometimes it likes to install setuptools...even if it's already in the package dependencies)
+        uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+        with:
+          role-to-assume: arn:aws:iam::{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}:role/CoreInfraBaseAccess
+          aws-region: {% endraw %}{{ aws_org_home_region }}{% raw %}
+
+{% endraw %}{% endif %}{% raw %}
       - name: Build package
-        run: uv build --no-sources{% endraw %}
+        run: |
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
+          uv build --no-sources
+
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+      - name: OIDC Auth for Publishing to CodeArtifact
+        uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+        with:
+          role-to-assume: arn:aws:iam::{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}:role/GHA-CA-Primary-{% endraw %}{{ repo_name }}{% raw %}
+          aws-region: {% endraw %}{{ aws_org_home_region }}{% raw %}
+
+{% endraw %}{% endif %}{% raw %}
+
+      - name: Publish package
+        run: |
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
+          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-primary --username aws --password "$TWINE_PASSWORD"{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -121,4 +121,4 @@ jobs:
       - name: Publish package
         run: |
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
-          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-primary --username aws --password "$TWINE_PASSWORD"{% else %}testpypi{% endif %}
+          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-primary --username aws --password "$TWINE_PASSWORD"{% else %}pypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.jinja
+++ b/template/.github/workflows/publish_to_staging.jinja
@@ -1,0 +1,97 @@
+{% raw %}name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+env:
+  PYTHONUNBUFFERED: True
+  PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
+
+permissions:
+    id-token: write
+    contents: write # needed for mutex
+
+jobs:
+  lint:
+    name: Pre-commit
+    runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+      - name: Install latest versions of python packages
+        uses: ./.github/actions/install_deps_uv
+        with:
+          python-version: {% endraw %}{{ python_version }}{% raw %}
+
+      - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
+        if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14
+        uses: ben-z/gh-action-mutex@{% endraw %}{{ gha_mutex }}{% raw %}
+        with:
+          branch: mutex-venv-{% endraw %}{{ gha_linux_runner }}{% raw %}-py{% endraw %}{{ python_version }}{% raw %}
+        timeout-minutes: 30 # this is the amount of time this action will wait to attempt to acquire the mutex lock before failing, e.g. if other jobs are queued up in front of it
+
+      - name: Cache Pre-commit hooks
+        uses: actions/cache@{% endraw %}{{ gha_cache }}{% raw %}
+        env:
+          cache-name: cache-pre-commit-hooks
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: {% endraw %}{{ gha_linux_runner }}{% raw %}-py{% endraw %}{{ python_version }}{% raw %}-build-${{ env.cache-name }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            {% endraw %}{{ gha_linux_runner }}{% raw %}-py{% endraw %}{{ python_version }}{% raw %}-build-${{ env.cache-name }}-
+
+      - name: Run pre-commit
+        run:  pre-commit run -a
+
+  test:
+    needs: [ lint ]
+    strategy:
+      matrix:
+        os:
+          - "{% endraw %}{{ gha_linux_runner }}{% raw %}"
+{% endraw %}{% if use_windows_in_ci %}          - {{ gha_windows_runner }}{% endif %}{% raw %}
+        python-version:
+{% endraw %}{% for item in python_ci_versions %}
+          - {{ item }}
+{% endfor %}{% raw %}
+        include:
+          - os: "{% endraw %}{{ gha_linux_runner }}{% raw %}"
+            python-version: "{% endraw %}{{ python_ci_versions[0] }}{% raw %}"
+            JOB_MATCHING_DEV_ENV: true
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+      - name: Install python tooling
+        uses: ./.github/actions/install_deps_uv
+        with:
+          python-version: ${{ matrix.python-version }}{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: "{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}"
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
+
+      - name: Unit test
+        run: uv run pytest --durations=5
+
+  build:
+    needs: [ test ]
+    runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@{% endraw %}{{ gha_checkout }}{% raw %}
+
+      - name: Install python tooling
+        uses: ./.github/actions/install_deps_uv
+        with:
+          python-version: {% endraw %}{{ python_version }}{% raw %}{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: "{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}"
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
+
+      - name: Build package
+        run: uv build --no-sources{% endraw %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -81,7 +81,7 @@ jobs:
         run: uv run pytest --durations=5
 
   build:
-    # needs: [ test ]
+    needs: [ test ]
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
 
     steps:
@@ -119,5 +119,4 @@ jobs:
       - name: Publish package
         run: |
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
-          env
           uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging --username aws --password "$TWINE_PASSWORD"{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -1,4 +1,4 @@
-{% raw %}name: Publish to PyPI
+{% raw %}name: Publish to Staging Package Registry
 
 on:
   workflow_dispatch:

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -120,4 +120,4 @@ jobs:
         run: |
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
           env
-          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}
+          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging --username aws --password "$TWINE_PASSWORD"{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -81,7 +81,7 @@ jobs:
         run: uv run pytest --durations=5
 
   build:
-    needs: [ test ]
+    # needs: [ test ]
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
 
     steps:

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -118,6 +118,6 @@ jobs:
 
       - name: Publish package
         run: |
-          env
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
+          env
           uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -118,5 +118,6 @@ jobs:
 
       - name: Publish package
         run: |
+          env
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
           uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -104,9 +104,11 @@ jobs:
 
 {% endraw %}{% endif %}{% raw %}
       - name: Build package
-        run: uv build --no-sources
+        run: |
+          . .devcontainer/code-artifact-auth.sh
+          uv build --no-sources
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
-      - name: OIDC Auth for CodeArtifact
+      - name: OIDC Auth for Publishing to CodeArtifact
         uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
         with:
           role-to-assume: arn:aws:iam::{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}:role/GHA-CA-Staging-{% endraw %}{{ repo_name }}{% raw %}
@@ -115,4 +117,6 @@ jobs:
 {% endraw %}{% endif %}{% raw %}
 
       - name: Publish package
-        run: uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}
+        run: |
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
+          uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -120,4 +120,4 @@ jobs:
         run: |
           env
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
-          uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}
+          uv publish --verbose --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -94,4 +94,7 @@ jobs:
           code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
 
       - name: Build package
-        run: uv build --no-sources{% endraw %}
+        run: uv build --no-sources
+
+      - name: Publish package
+        run: uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -95,7 +95,14 @@ jobs:
           code-artifact-auth-role-name: CoreInfraBaseAccess
           code-artifact-auth-role-account-id: "{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}"
           code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+      - name: OIDC Auth for Installing any dependencies that uv may need for build (sometimes it likes to install setuptools...even if it's already in the package dependencies)
+        uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+        with:
+          role-to-assume: arn:aws:iam::{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}:role/CoreInfraBaseAccess
+          aws-region: {% endraw %}{{ aws_org_home_region }}{% raw %}
 
+{% endraw %}{% endif %}{% raw %}
       - name: Build package
         run: uv build --no-sources
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -105,7 +105,7 @@ jobs:
 {% endraw %}{% endif %}{% raw %}
       - name: Build package
         run: |
-          . .devcontainer/code-artifact-auth.sh
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}          . .devcontainer/code-artifact-auth.sh{% endraw %}{% endif %}{% raw %}
           uv build --no-sources
 {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
       - name: OIDC Auth for Publishing to CodeArtifact

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -22,7 +22,10 @@ jobs:
       - name: Install latest versions of python packages
         uses: ./.github/actions/install_deps_uv
         with:
-          python-version: {% endraw %}{{ python_version }}{% raw %}
+          python-version: {% endraw %}{{ python_version }}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+          code-artifact-auth-role-name: CoreInfraBaseAccess
+          code-artifact-auth-role-account-id: {% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}
+          code-artifact-auth-region: {% endraw %}{{ aws_org_home_region }}{% endif %}{% raw %}
 
       - name: Set up mutex # Github concurrency management is horrible, things get arbitrarily cancelled if queued up. So using mutex until github fixes itself. When multiple jobs are modifying cache at once, weird things can happen.  possible issue is https://github.com/actions/toolkit/issues/658
         if: ${{ runner.os != 'Windows' }} # we're just gonna have to YOLO on Windows, because this action doesn't support it yet https://github.com/ben-z/gh-action-mutex/issues/14

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -98,6 +98,14 @@ jobs:
 
       - name: Build package
         run: uv build --no-sources
+{% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}{% raw %}
+      - name: OIDC Auth for CodeArtifact
+        uses: aws-actions/configure-aws-credentials@{% endraw %}{{ gha_configure_aws_credentials }}{% raw %}
+        with:
+          role-to-assume: arn:aws:iam::{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}:role/GHA-CA-Staging-{% endraw %}{{ repo_name }}{% raw %}
+          aws-region: {% endraw %}{{ aws_org_home_region }}{% raw %}
+
+{% endraw %}{% endif %}{% raw %}
 
       - name: Publish package
         run: uv publish --index {% endraw %}{% if python_package_registry == "AWS CodeArtifact" %}code-artifact-staging{% else %}testpypi{% endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -53,11 +53,13 @@ publish-url = "https://test.pypi.org/legacy/"{% endraw %}{% else %}{% raw %}
 default = true
 name = "code-artifact-primary"
 username = "aws"
+publish-username = "aws"
 url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-primary/simple/"
 publish-url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-primary/"
 
 [[tool.uv.index]]
 name = "code-artifact-staging"
 username = "aws"
+publish-username = "aws"
 url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-staging/simple/"
 publish-url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-staging/"{% endraw %}{% endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -29,7 +29,6 @@ dev = [
     "pytest>={% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov>={% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly>={% endraw %}{{ pytest_randomly_version }}{% raw %}",
-    "setuptools>={% endraw %}{{ setuptools_version }}{% raw %}", # likely related to the kludge for license-files below
 {% endraw %}{% if create_docs %}{% raw %}    "sphinx=={% endraw %}{{ sphinx_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if is_frozen_executable %}{% raw %}    "pyinstaller>={% endraw %}{{ pyinstaller_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 ]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -54,8 +54,10 @@ default = true
 name = "code-artifact-primary"
 username = "aws"
 url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-primary/simple/"
+publish-url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-primary/"
 
 [[tool.uv.index]]
 name = "code-artifact-staging"
 username = "aws"
-url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-staging/simple/"{% endraw %}{% endif %}
+url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-staging/simple/"
+publish-url = "https://{% endraw %}{{ repo_org_name }}{% raw %}-{% endraw %}{{ aws_central_infrastructure_account_id }}{% raw %}.d.codeartifact.{% endraw %}{{ aws_org_home_region }}{% raw %}.amazonaws.com/pypi/{% endraw %}{{ repo_org_name }}{% raw %}-staging/"{% endraw %}{% endif %}

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -29,7 +29,7 @@ dev = [
     "pytest>={% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov>={% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly>={% endraw %}{{ pytest_randomly_version }}{% raw %}",
-    "setuptools">={% endraw %}{{ setuptools_version }}{% raw %}", # likely related to the kludge for license-files below
+    "setuptools>={% endraw %}{{ setuptools_version }}{% raw %}", # likely related to the kludge for license-files below
 {% endraw %}{% if create_docs %}{% raw %}    "sphinx=={% endraw %}{{ sphinx_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if is_frozen_executable %}{% raw %}    "pyinstaller>={% endraw %}{{ pyinstaller_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 ]

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -21,7 +21,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    # Specific to this template
+    # Specific to this repository
 
 
     # Managed by upstream template
@@ -29,6 +29,7 @@ dev = [
     "pytest>={% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov>={% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly>={% endraw %}{{ pytest_randomly_version }}{% raw %}",
+    "setuptools">={% endraw %}{{ setuptools_version }}{% raw %}", # likely related to the kludge for license-files below
 {% endraw %}{% if create_docs %}{% raw %}    "sphinx=={% endraw %}{{ sphinx_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 {% endraw %}{% if is_frozen_executable %}{% raw %}    "pyinstaller>={% endraw %}{{ pyinstaller_version }}{% raw %}",{% endraw %}{% endif %}{% raw %}
 ]


### PR DESCRIPTION
 ## Why is this change necessary?
Need to be able to have workflows that publish to CodeArtifact


 ## How does this change address the issue?
Creates a workflow to publish to the staging repository, and one for the primary repository


 ## What side effects does this change have?
None


 ## How is this change tested?
In a downstream repo that successfully published

