### PR TITLE
Ignore sphinx minor versions for dependabot

### DIFF
--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -15,6 +15,7 @@ updates:
       - dependency-name: "sphinx*" # read-the-docs uses specific versions of sphinx, so we generally want to stay tightly pinned unless there's a major version change
         update-types:
           - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
     groups:
       prod-dependencies:

--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -12,6 +12,9 @@ updates:
       - dependency-name: "boto3" # boto3 gets patch updates way too frequently and they're usually not important
         update-types:
           - "version-update:semver-patch"
+      - dependency-name: "sphinx*" # read-the-docs uses specific versions of sphinx, so we generally want to stay tightly pinned unless there's a major version change
+        update-types:
+          - "version-update:semver-minor"
 
     groups:
       prod-dependencies:


### PR DESCRIPTION
 ## Why is this change necessary?
dependabot was updating sphinx


 ## How does this change address the issue?
stops it


 ## What side effects does this change have?
N/A


 ## How is this change tested?
isn't
