### PR TITLE
Publish patch

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.49
+_commit: v0.0.54-6-gf575ff7
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.54-6-gf575ff7
+_commit: v0.0.55
 _src_path: gh:LabAutomationAndScreening/copier-base-template.git
 description: Copier template for creating Python libraries and executables
 python_ci_versions:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,5 +61,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): dfcd01a5 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 6ebb97a5 # spellchecker:disable-line
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,9 +22,7 @@ updates:
         dependency-type: "production"
         update-types:
           - "minor"
-          - "patch"
       dev-dependencies:
         dependency-type: "development"
         update-types:
           - "minor"
-          - "patch"

--- a/extensions/context.py
+++ b/extensions/context.py
@@ -10,23 +10,23 @@ class ContextUpdater(ContextHook):
 
     @override
     def hook(self, context: dict[Any, Any]) -> dict[Any, Any]:
-        context["uv_version"] = "0.7.8"
-        context["pnpm_version"] = "10.11.0"
+        context["uv_version"] = "0.7.12"
+        context["pnpm_version"] = "10.12.1"
         context["pre_commit_version"] = "4.2.0"
-        context["pyright_version"] = "1.1.400"
-        context["pytest_version"] = "8.3.5"
+        context["pyright_version"] = "1.1.402"
+        context["pytest_version"] = "8.4.0"
         context["pytest_randomly_version"] = "3.16.0"
-        context["pytest_cov_version"] = "6.1.1"
+        context["pytest_cov_version"] = "6.2.1"
         context["copier_version"] = "9.7.1"
         context["copier_templates_extension_version"] = "0.3.1"
         context["sphinx_version"] = "8.1.3"
-        context["pulumi_version"] = "3.171.0"
-        context["pulumi_aws_version"] = "6.81.0"
-        context["pulumi_aws_native_version"] = "1.27.0"
+        context["pulumi_version"] = "3.177.0"
+        context["pulumi_aws_version"] = "6.83.0"
+        context["pulumi_aws_native_version"] = "1.30.0"
         context["pulumi_command_version"] = "1.1.0"
         context["pulumi_github_version"] = "6.7.2"
-        context["pulumi_okta_version"] = "4.18.0"
-        context["boto3_version"] = "1.38.18"
+        context["pulumi_okta_version"] = "4.20.0"
+        context["boto3_version"] = "1.38.38"
         context["ephemeral_pulumi_deploy_version"] = "0.0.4"
         context["pydantic_version"] = "2.11.5"
         context["pyinstaller_version"] = "6.13.0"
@@ -34,14 +34,14 @@ class ContextUpdater(ContextHook):
         context["strawberry_graphql_version"] = "0.270.4"
         context["fastapi_version"] = "0.115.12"
         context["uvicorn_version"] = "0.34.2"
-        context["lab_auto_pulumi_version"] = "0.1.12"
+        context["lab_auto_pulumi_version"] = "0.1.14"
 
         context["nuxt_ui_version"] = "^3.1.2"
         context["nuxt_version"] = "^3.17.3"
         context["typescript_version"] = "^5.8.2"
         context["vue_version"] = "^3.5.13"
         context["vue_router_version"] = "^4.5.0"
-        context["faker_version"] = "^9.7.0"
+        context["faker_version"] = "^9.8.0"
         context["graphql_codegen_cli_version"] = "^5.0.5"
         context["graphql_codegen_typescript_version"] = "^4.1.6"
 
@@ -69,7 +69,8 @@ class ContextUpdater(ContextHook):
         context["py313_version"] = "3.13.2"
 
         context["debian_release_name"] = "bookworm"
-        context["alpine_image_version"] = "3.20"
+        context["alpine_image_version"] = "3.21"
+        context["nginx_image_version"] = "1.28.0"
 
         # Kludge to be able to help symlinked jinja files in the child and grandchild templates
         context["template_uses_vuejs"] = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,10 @@ readme = "README.md"
 requires-python = ">=3.12.7"
 dependencies = [
     # Managed by upstream template
-    "pytest>=8.3.5",
-    "pytest-cov>=6.1.1",
+    "pytest>=8.4.0",
+    "pytest-cov>=6.2.1",
     "pytest-randomly>=3.16.0",
-    "pyright[nodejs]==1.1.400", # temporarily pin due to bug in 1.1.401 https://github.com/microsoft/pyright/issues/10487
+    "pyright[nodejs]>=1.1.402",
     "copier>=9.7.1",
     "copier-templates-extensions>=0.3.1"
 

--- a/template/.devcontainer/install-ci-tooling.py.jinja
+++ b/template/.devcontainer/install-ci-tooling.py.jinja
@@ -1,16 +1,19 @@
-import argparse
+{% raw %}import argparse
 import os
 import platform
 import shutil
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
-UV_VERSION = "0.7.8"
-PNPM_VERSION = "10.11.0"
-COPIER_VERSION = "9.7.1"
-COPIER_TEMPLATES_EXTENSION_VERSION = "0.3.1"
-PRE_COMMIT_VERSION = "4.2.0"
+UV_VERSION = "{% endraw %}{{ uv_version }}{% raw %}"
+PNPM_VERSION = "{% endraw %}{{ pnpm_version }}{% raw %}"
+COPIER_VERSION = "{% endraw %}{{ copier_version }}{% raw %}"
+COPIER_TEMPLATES_EXTENSION_VERSION = "{% endraw %}{{ copier_templates_extension_version }}{% raw %}"
+PRE_COMMIT_VERSION = "{% endraw %}{{ pre_commit_version }}{% raw %}"
 GITHUB_WINDOWS_RUNNER_BIN_PATH = r"C:\Users\runneradmin\.local\bin"
+INSTALL_SSM_PLUGIN_BY_DEFAULT = {% endraw %}{% if is_child_of_copier_base_template is not defined and install_aws_ssm_port_forwarding_plugin is defined and install_aws_ssm_port_forwarding_plugin is sameas(true) %}True{% else %}False{% endif %}{% raw %}
 parser = argparse.ArgumentParser(description="Install CI tooling for the repo")
 _ = parser.add_argument(
     "--no-python",
@@ -26,6 +29,12 @@ _ = parser.add_argument(
 )
 _ = parser.add_argument(
     "--no-node", action="store_true", default=False, help="Do not process any environments using node package managers"
+)
+_ = parser.add_argument(
+    "--install-ssm-plugin",
+    action="store_true",
+    default=INSTALL_SSM_PLUGIN_BY_DEFAULT,
+    help="Install the SSM plugin for AWS CLI",
 )
 
 
@@ -108,7 +117,31 @@ def main():
                 else [cmd]
             )
             _ = subprocess.run(cmd, shell=True, check=True)
+    if args.install_ssm_plugin:
+        if is_windows:
+            raise NotImplementedError("SSM plugin installation is not implemented for Windows")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            local_package_path = Path(tmp_dir) / "session-manager-plugin.deb"
+            # Based on https://docs.aws.amazon.com/systems-manager/latest/userguide/install-plugin-debian-and-ubuntu.html
+            # no specific reason for that version, just pinning it for best practice
+            _ = subprocess.run(
+                [
+                    "curl",
+                    "https://s3.amazonaws.com/session-manager-downloads/plugin/1.2.707.0/ubuntu_64bit/session-manager-plugin.deb",
+                    "-o",
+                    f"{local_package_path}",
+                ],
+                check=True,
+            )
+            _ = subprocess.run(
+                ["sudo", "dpkg", "-i", str(local_package_path)],
+                check=True,
+            )
+            _ = subprocess.run(
+                ["session-manager-plugin", "--version"],
+                check=True,
+            )
 
 
 if __name__ == "__main__":
-    main()
+    main(){% endraw %}

--- a/template/.github/dependabot.yml.jinja
+++ b/template/.github/dependabot.yml.jinja
@@ -22,9 +22,7 @@ updates:
         dependency-type: "production"
         update-types:
           - "minor"
-          - "patch"
       dev-dependencies:
         dependency-type: "development"
         update-types:
-          - "minor"
-          - "patch"{% endraw %}
+          - "minor"{% endraw %}

--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -164,7 +164,7 @@ jobs:
         with:
           time: 60s{% endraw %}{% endif %}{% raw %}
       - name: Install from staging registry
-        run: pip install -i https://test.pypi.org/simple/ {% endraw %}{{ package_name | replace('_', '-') }}{% raw %}==${{ needs.get-values.outputs.package-version }}
+        run: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://www.pypi.org/simple {% endraw %}{{ package_name | replace('_', '-') }}{% raw %}==${{ needs.get-values.outputs.package-version }}
       - name: Confirm library can be imported successfully
         run: python -c "import {% endraw %}{{ package_name | replace('-', '_') }}{% raw %}"
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -25,7 +25,7 @@ dev = [
 
 
     # Managed by upstream template
-    "pyright=={% endraw %}{{ pyright_version }}{% raw %}", # temporarily pin due to bug in 1.1.401 https://github.com/microsoft/pyright/issues/10487
+    "pyright>={% endraw %}{{ pyright_version }}{% raw %}",
     "pytest>={% endraw %}{{ pytest_version }}{% raw %}",
     "pytest-cov>={% endraw %}{{ pytest_cov_version }}{% raw %}",
     "pytest-randomly>={% endraw %}{{ pytest_randomly_version }}{% raw %}",

--- a/uv.lock
+++ b/uv.lock
@@ -61,9 +61,9 @@ dependencies = [
 requires-dist = [
     { name = "copier", specifier = ">=9.7.1" },
     { name = "copier-templates-extensions", specifier = ">=0.3.1" },
-    { name = "pyright", extras = ["nodejs"], specifier = "==1.1.400" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.402" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
 ]
 
@@ -358,15 +358,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.400"
+version = "1.1.402"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/c306618a02d0ee8aed5fb8d0fe0ecfed0dbf075f71468f03a30b5f4e1fe0/pyright-1.1.400.tar.gz", hash = "sha256:b8a3ba40481aa47ba08ffb3228e821d22f7d391f83609211335858bf05686bdb", size = 3846546 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/04/ce0c132d00e20f2d2fb3b3e7c125264ca8b909e693841210534b1ea1752f/pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683", size = 3888207 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/a5/5d285e4932cf149c90e3c425610c5efaea005475d5f96f1bfdb452956c62/pyright-1.1.400-py3-none-any.whl", hash = "sha256:c80d04f98b5a4358ad3a35e241dbf2a408eee33a40779df365644f8054d2517e", size = 5563460 },
+    { url = "https://files.pythonhosted.org/packages/fe/37/1a1c62d955e82adae588be8e374c7f77b165b6cb4203f7d581269959abbc/pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982", size = 5624004 },
 ]
 
 [package.optional-dependencies]
@@ -376,30 +376,32 @@ nodejs = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+sdist = { url = "https://files.pythonhosted.org/packages/08/ba/45911d754e8eba3d5a841a5ce61a65a685ff1798421ac054f85aa8747dfb/pytest-8.4.1.tar.gz", hash = "sha256:7c67fd69174877359ed9371ec3af8a3d2b04741818c51e5e99cc1742251fa93c", size = 1517714 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+    { url = "https://files.pythonhosted.org/packages/29/16/c8a903f4c4dffe7a12843191437d7cd8e32751d5de349d45d3fe69544e87/pytest-8.4.1-py3-none-any.whl", hash = "sha256:539c70ba6fcead8e78eebbf1115e8b589e7565830d7d006a8723f19ac8a0afb7", size = 365474 },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "6.1.1"
+version = "6.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage" },
+    { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/69/5f1e57f6c5a39f81411b550027bf72842c4567ff5fd572bed1edc9e4b5d9/pytest_cov-6.1.1.tar.gz", hash = "sha256:46935f7aaefba760e716c2ebfbe1c216240b9592966e7da99ea8292d4d3e2a0a", size = 66857 }
+sdist = { url = "https://files.pythonhosted.org/packages/18/99/668cade231f434aaa59bbfbf49469068d2ddd945000621d3d165d2e7dd7b/pytest_cov-6.2.1.tar.gz", hash = "sha256:25cc6cc0a5358204b8108ecedc51a9b57b34cc6b8c967cc2c01a4e00d8a67da2", size = 69432 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/d0/def53b4a790cfb21483016430ed828f64830dd981ebe1089971cd10cab25/pytest_cov-6.1.1-py3-none-any.whl", hash = "sha256:bddf29ed2d0ab6f4df17b4c55b0a657287db8684af9c42ea546b21b1041b3dde", size = 23841 },
+    { url = "https://files.pythonhosted.org/packages/bc/16/4ea354101abb1287856baa4af2732be351c7bee728065aed451b678153fd/pytest_cov-6.2.1-py3-none-any.whl", hash = "sha256:f5bc4c23f42f1cdd23c70b1dab1bbaef4fc505ba950d53e0081d0730dd7e86d5", size = 24644 },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Why is this change necessary?
In CI, when installing from the pypi testing registry, project sub-dependencies weren't always there


 ## How does this change address the issue?
Added the main PyPI registry as backup


 ## What side effects does this change have?
None


 ## How is this change tested?
Isn't


 ## Other
Pulled in some upstream template updates