### PR TITLE
Fix publish job permissions

### DIFF
--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -197,6 +197,8 @@ jobs:
     name: Create the git tag
     if: ${{ github.event.inputs.publish_to_primary }}
     needs: [ install-from-staging ]
+    permissions:
+      contents: write # needed to push the tag
     runs-on: {% endraw %}{{ gha_linux_runner }}{% raw %}
     steps:
       - name: Checkout code

--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -185,13 +185,13 @@ jobs:
       - name: Sleep to allow PyPI Index to update before proceeding to the next step
         uses: juliangruber/sleep-action@{% endraw %}{{ gha_sleep }}{% raw %}
         with:
-          time: 60s{% endraw %}{% endif %}{% raw %}
+          time: 90s{% endraw %}{% endif %}{% raw %}
       - name: Install from staging registry
         run: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://www.pypi.org/simple {% endraw %}{{ package_name | replace('_', '-') }}{% raw %}==${{ needs.get-values.outputs.package-version }}
       - name: Display dependencies
         run: pip list
       - name: Confirm library can be imported successfully
-        run: python -c "import {% endraw %}{{ package_name | replace('-', '_') }}{% raw %}"
+        run: python -c "import sys; print(f'Python version {sys.version}'); import {% endraw %}{{ package_name | replace('-', '_') }}{% raw %}"
 
   create-tag:
     name: Create the git tag
@@ -278,10 +278,10 @@ jobs:
       - name: Sleep to allow PyPI Index to update before proceeding to the next step
         uses: juliangruber/sleep-action@{% endraw %}{{ gha_sleep }}{% raw %}
         with:
-          time: 60s{% endraw %}{% endif %}{% raw %}
+          time: 90s{% endraw %}{% endif %}{% raw %}
       - name: Install from primary registry
         run: pip install {% endraw %}{{ package_name | replace('_', '-') }}{% raw %}==${{ needs.get-values.outputs.package-version }}
       - name: Display dependencies
         run: pip list
       - name: Confirm library can be imported successfully
-        run: python -c "import {% endraw %}{{ package_name | replace('-', '_') }}{% raw %}"{% endraw %}
+        run: python -c "import sys; print(f'Python version {sys.version}'); import {% endraw %}{{ package_name | replace('-', '_') }}{% raw %}"{% endraw %}


### PR DESCRIPTION
 ## Why is this change necessary?
The publish job is currently missing permission to push the git tag
https://github.com/LabAutomationAndScreening/pyalab/actions/runs/16704553688/job/47280840075


 ## How does this change address the issue?
Adds permission


 ## What side effects does this change have?
None


 ## How is this change tested?
Can't until after merge


 ## Other
Also handled https://github.com/LabAutomationAndScreening/copier-python-package-template/issues/54
Also bumped up the sleep time for PyPI index to populate since there have been cases where 60s was not enough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased wait time before package installation from PyPI registries to improve reliability.
  * Enhanced confirmation step to display the Python version before importing the installed package.
  * Updated workflow permissions to support git tag creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->