### PR TITLE
Fix read contents CI permissions

### DIFF
--- a/template/.github/workflows/ci.yaml.jinja
+++ b/template/.github/workflows/ci.yaml.jinja
@@ -12,6 +12,7 @@ env:
 
 permissions:
   id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   get-values:

--- a/template/.github/workflows/publish.yaml.jinja
+++ b/template/.github/workflows/publish.yaml.jinja
@@ -14,6 +14,7 @@ env:
 
 permissions:
   id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   get-values:

--- a/template/.github/workflows/publish_to_staging.yaml.jinja
+++ b/template/.github/workflows/publish_to_staging.yaml.jinja
@@ -8,7 +8,8 @@ env:
   PRE_COMMIT_HOME: ${{ github.workspace }}/.precommit_cache
 
 permissions:
-    id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  id-token: write # needed to assume OIDC roles (e.g. for downloading from CodeArtifact)
+  contents: read # need to explicitly provide this whenever defining permissions because the default value is 'none' for anything not explicitly set when permissions are defined
 
 jobs:
   lint:


### PR DESCRIPTION
 ## Why is this change necessary?
Read contents permission is lost when redefining permissions explicitly, so any private repos fail to be able to checkout code


 ## How does this change address the issue?
explicitly grants read contents permission wherever permissions are redefined and it's needed


 ## What side effects does this change have?
none


 ## How is this change tested?
downstream repo